### PR TITLE
Fix form clearing in lab 2

### DIFF
--- a/Lab-2-Data/README.md
+++ b/Lab-2-Data/README.md
@@ -204,7 +204,12 @@ Use the following Razor markup to create a basic form, replacing the contents of
     private SupportTicket Ticket { get; set; } = new();
     private List<SupportTicket> Tickets = [];
 
-    private void ClearForm() => Ticket = new();
+    private void ClearForm()
+    {
+        Ticket = new();
+        StateHasChanged();
+
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/Lab-2-Data/end/AspireSQLEFCore/Components/Pages/Home.razor
+++ b/Lab-2-Data/end/AspireSQLEFCore/Components/Pages/Home.razor
@@ -41,7 +41,12 @@
     private SupportTicket Ticket { get; set; } = new();
     private List<SupportTicket> Tickets = [];
 
-    private void ClearForm() => Ticket = new();
+    private void ClearForm()
+    {
+        Ticket = new();
+        StateHasChanged();
+
+    }
 
     protected override async Task OnInitializedAsync()
     {


### PR DESCRIPTION
Fixes #4 

This pull request includes changes in the `ClearForm()` method in two files: `Lab-2-Data/README.md` and `Lab-2-Data/end/AspireSQLEFCore/Components/Pages/Home.razor`. The changes involve expanding the `ClearForm()` method to include a call to `StateHasChanged()` after resetting the `Ticket` object.

Changes:

* [`Lab-2-Data/README.md`](diffhunk://#diff-73234704c89ec93a59a458ca5179abc7e541f39e0af783c25e99a445e89ec305L207-R212): The `ClearForm()` method has been expanded to include a call to `StateHasChanged()` after resetting the `Ticket` object. This ensures that the state of the component is updated after the form is cleared.
* [`Lab-2-Data/end/AspireSQLEFCore/Components/Pages/Home.razor`](diffhunk://#diff-22f6f3b176c755db9669bf9bbee52c140d38b91a3bcd4a913fc52bf566aa9dbeL44-R49): Similar changes have been made in this file as well, with the `ClearForm()` method now including a call to `StateHasChanged()`.